### PR TITLE
Fixed configuration loading priority to favor custom desktop command

### DIFF
--- a/wpreddit/wallpaper.py
+++ b/wpreddit/wallpaper.py
@@ -19,7 +19,9 @@ def set_wallpaper():
 def linux_wallpaper():
     de = os.environ.get('DESKTOP_SESSION')
     path = os.path.expanduser("~/.wallpaper/wallpaper.jpg")
-    if de in ["gnome", "unity", "ubuntu"]:
+    if config.setcmd != '':
+        os.system(config.setcmd)
+    elif de in ["gnome", "unity", "ubuntu"]:
         os.system("gsettings set org.gnome.desktop.background picture-uri file://%s" % path)
     elif de in ["cinnamon"]:
         os.system("gsettings set org.cinnamon.desktop.background picture-uri file://%s" % path)


### PR DESCRIPTION
# Introduction
Fixed configuration loading priority to favor a user's input of a custom desktop command- if they changed the custom command, that should be higher priority and chosen first, not after scanning for desktop environments. 

# Purpose
If the user is specifying a custom command, it is likely because the script has prompted them to, or they otherwise "know what they're doing". Thus it should come first.

Additionally, alternative setups, such as XFCE on laptops, often, will be detected as XFCE correctly but need a custom command to set their wallpaper background. This change shouldn't interfere with regular function.

# Summary of code changes
linux_wallpaper() now checks if the custom command is specified before the environment is set to be detected. If it is, then the only way this could have done before in code is from loading prior from the config file; thus we have our command and don't need to detect environment. If it isn't the function runs as baseline.