### PR TITLE
Rewrote save-wallpaper for readability + fixed broken titling scheme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-        name='Wallpaper Reddit',
+        name='wallpaper-reddit',
         version='3.0',
         packages=find_packages(),
         url='https://www.github.com/markubiak/wallpaper-reddit',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
         name='wallpaper-reddit',
-        version='3.0',
+        version='3.0.0',
         packages=find_packages(),
         url='https://www.github.com/markubiak/wallpaper-reddit',
         author='Mark Kubiak',


### PR DESCRIPTION
# Introduction
Rewrote save-wallpaper in wallpaper.py, at first to fix a bug that would save over the same "wallpaper0.jpg" repeatedly rather than have a proper titling scheme, then for clearer logic.

# Purpose
Without this fix, saving wallpapers would repeatedly save to "wallpaper0", and titles.txt would fill up with the correct titles attached to "wallpaper0". Additionally code readability improvement is generally a good idea. This also fixes a minor bug where Windows users would see their output call the saved wallpaper path a JPG image and has a minor grammar fix.

# Summary of code changes
save_wallpaper() now assembles the paths of the old and new wallpaper images once and reuses this instead of having it be re-assembled at each function call requiring it. This is slightly more efficient. Additionally, the counter for figuring out the wallpaper file name suffix is now properly utilized when saving the file, and is renamed for clarity.