### PR TITLE
[Ratio] Add minratio config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If no subreddits are specified, the script will default to the top image from th
 The config file is in `~/.config/wallpaper-reddit`, and will be created automatically.  Currently, the GNOME, XFCE, MATE, Unity, and Cinnamon Desktop Environments should be automatically detected and the program should set the wallpaper without any extra work.  However, due to the varying nature of window managers, it is possible, even likely, that you may have to specify a custom command to set your wallpaper.  The program will prompt you for this if this is the case; the exact command can be researched per desktop environment.  If your desktop environment is not supported, please file an issue so that automatic support can be implemented for others.  
 ### Config Options:  
 - `minwidth` and `minheight` set the minimum dimensions the program will consider a valid candidate for a wallpaper.  If `--resize` is enabled, the script will resize the image to those dimensions before setting the wallpaper.
+- `minratio` is the minimal aspect ratio of the image. It is a float value of width/height of the image, for example 1.6 for 16:9 image.
 - `maxlinks` is the maximum number of links the script will go through before giving up.
 - `resize` does the same thing as the `--resize` flag.  It is enabled by default.
 - `random` does the same thing as the `--random` flag.

--- a/wpreddit/conf_files/unix.conf
+++ b/wpreddit/conf_files/unix.conf
@@ -6,6 +6,8 @@ setcommand =
 subs = earthporn,spaceporn
 minwidth = 1920
 minheight = 1080
+# Float value for minimal aspect ratio of the picture, e.g. 1.6 for 16:9
+minratio = 0.0
 maxlinks = 20
 resize = True
 random = False

--- a/wpreddit/conf_files/windows.conf
+++ b/wpreddit/conf_files/windows.conf
@@ -6,6 +6,8 @@ minwidth = 1920
 
 minheight = 1080
 
+minratio = 0.0
+
 maxlinks = 20
 
 resize = True

--- a/wpreddit/config.py
+++ b/wpreddit/config.py
@@ -16,6 +16,7 @@ save = False
 subs = []
 minwidth = 0
 minheight = 0
+minratio = 0.0
 titlesize = 0
 titlealign_x = ""
 titlealign_y = ""
@@ -80,6 +81,7 @@ def parse_config():
     global maxlinks
     global minheight
     global minwidth
+    global minratio
     global settitle
     global titlesize
     global titlealign_x
@@ -103,6 +105,7 @@ def parse_config():
     maxlinks = config.getint('Options', 'maxlinks', fallback=20)
     minwidth = config.getint('Options', 'minwidth', fallback=1920)
     minheight = config.getint('Options', 'minheight', fallback=1080)
+    minratio = config.getfloat('Options', 'minratio', fallback=0.0)
     resize = config.getboolean('Options', 'resize', fallback=True)
     randomsub = config.getboolean('Options', 'random', fallback=False)
     lottery = config.getboolean('Options', 'lottery', fallback=False)

--- a/wpreddit/reddit.py
+++ b/wpreddit/reddit.py
@@ -88,9 +88,10 @@ def check_dimensions(url):
     try:
         with Image.open(resp) as img:
             dimensions = img.size
-            if dimensions[0] >= config.minwidth and dimensions[1] >= config.minheight:
-                config.log("Size checks out")
-                return True
+            if (dimensions[0] / dimensions[1]) >= config.minratio:
+                if dimensions[0] >= config.minwidth and dimensions[1] >= config.minheight:
+                    config.log("Size checks out")
+                    return True
     except IOError:
         config.log("Image dimensions could not be read")
     return False


### PR DESCRIPTION
Hi,

My use case is to filter out portrait images, as they don't look nice when resized. Therefore I added a new config option `minratio` where you can specify 1.6 for 16:9 for example. Default value is 0.0 so it should not break anything