### PR TITLE
Fix for pngs with alpha channel: Convert RGBA to RGB by layering image on a black background

### DIFF
--- a/wpreddit/download.py
+++ b/wpreddit/download.py
@@ -19,6 +19,9 @@ def download_image(url, title):
         if config.resize:
             config.log("resizing the downloaded wallpaper")
             img = ImageOps.fit(img, (config.minwidth, config.minheight), Image.ANTIALIAS)
+        if img.mode == "RGBA":
+            config.log("removing alpha layer")
+            img = pure_pil_alpha_to_color_v2(img)
         if config.settitle:
             img = set_image_title(img, title)
         if config.opsys == "Windows":
@@ -78,3 +81,15 @@ def save_info(link):
 # removes the [tags] throughout the image
 def remove_tags(str):
     return re.sub(' +', ' ', re.sub("[\[\(\<].*?[\]\)\>]", "", str)).strip()
+
+# in - PIL RGBA Image object - image with alpha channel
+# in - Tuple r, g, b (default 255, 255, 255) - colour of the background \
+# to paste the img on top of.
+# Alpha composite an RGBA Image with a specified color.
+# Source: http://stackoverflow.com/a/9459208/284318
+def pure_pil_alpha_to_color_v2(image, color=(255, 255, 255)):
+    image.load()  # needed for split()
+    background = Image.new('RGB', image.size, color)
+    background.paste(image, mask=image.split()[3])  # 3 is the alpha channel
+    return background
+


### PR DESCRIPTION
When png images have an alpha layer, they can retain them in RGBA mode even though we ask for RGB mode.
This causes img.save(..., "JPEG") to fail with IOError("cannot write mode
RGBA as JPEG").
This commit layers RGBA images on top of a black background before
removing the alpha channel and converting to RGB.

Example image that used to fail:  https://i.redd.it/gnro5oykh1821.png
Issue in Pillow: python-pillow/Pillow#2609
StackOverflow solution: http://stackoverflow.com/a/9459208/284318